### PR TITLE
Added try catch to exit function

### DIFF
--- a/receiver.py
+++ b/receiver.py
@@ -191,7 +191,7 @@ class Receiver:
         try:
             self.ser.close()
         except(AttributeError):
-            #If the program exits before ser is initiallized, ser.close() will throw an AttributeError
+            #If the program exits before ser is initiallized, ser.close() will throw an AttributeError, which is caught and ignored
             pass
         if isinstance(value, serial.SerialException):
             print(traceback)

--- a/receiver.py
+++ b/receiver.py
@@ -191,6 +191,7 @@ class Receiver:
         try:
             self.ser.close()
         except(AttributeError):
+            #If the program exits before ser is initiallized, ser.close() will throw an AttributeError
             pass
         if isinstance(value, serial.SerialException):
             print(traceback)

--- a/receiver.py
+++ b/receiver.py
@@ -188,7 +188,10 @@ class Receiver:
 
     def __exit__(self, type, value, traceback):
         self.xbee = None
-        self.ser.close()
+        try:
+            self.ser.close()
+        except(AttributeError):
+            pass
         if isinstance(value, serial.SerialException):
             print(traceback)
             return True


### PR DESCRIPTION
Sometimes the receiver will exit before self.ser is initialized. If this
happens, self.ser.close() will throw an exception, which will hide the
original exception being thrown. The added try/catch will cleanly catch the exception.
